### PR TITLE
Add Material inspired design

### DIFF
--- a/content.js
+++ b/content.js
@@ -20,18 +20,21 @@ async function injectSummaryWidget() {
     width: 400px;
     max-height: 60vh;
     background: white;
-    border: 1px solid #ccc;
-    box-shadow: 0 0 12px rgba(0,0,0,0.2);
-    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    border-radius: 4px;
     padding: 16px;
-    font-family: Arial, sans-serif;
+    font-family: Roboto, Arial, sans-serif;
     z-index: 999999;
     overflow-y: auto;
   `;
 
   const title = document.createElement('div');
   title.innerText = '🧠 Webpage Summary';
-  title.style = 'font-weight: bold; margin-bottom: 8px;';
+  title.style = `
+    font-weight: 500;
+    margin-bottom: 12px;
+    font-size: 1.1rem;
+  `;
 
   const content = document.createElement('div');
   content.innerHTML = '<p><em>Summarizing...</em></p>';
@@ -40,7 +43,16 @@ async function injectSummaryWidget() {
 
   const close = document.createElement('button');
   close.innerText = 'Dismiss';
-  close.style = 'margin-top: 10px; width: 100%;';
+  close.style = `
+    margin-top: 12px;
+    width: 100%;
+    background: #6200ee;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    cursor: pointer;
+  `;
   close.onclick = () => container.remove();
 
   container.appendChild(title);

--- a/popup.html
+++ b/popup.html
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <style>body { font-family: Arial; padding: 10px; }</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h3>Summarize Page</h3>
-  <input id="apiKeyInput" type="password" placeholder="OpenAI API Key" />
-  <button id="saveKeyBtn">Save Key</button>
-  <button id="summarizeBtn">Summarize</button>
-  <button id="removeAdsBtn">Remove Ads</button>
+  <h5 class="title">Summarize Page</h5>
+  <div class="input-field">
+    <input id="apiKeyInput" type="password" placeholder="OpenAI API Key">
+  </div>
+  <button id="saveKeyBtn" class="btn">Save Key</button>
+  <button id="summarizeBtn" class="btn">Summarize</button>
+  <button id="removeAdsBtn" class="btn grey">Remove Ads</button>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+body {
+  font-family: Roboto, Arial, sans-serif;
+  padding: 16px;
+  margin: 0;
+}
+
+.title {
+  margin-bottom: 20px;
+  font-size: 1.25rem;
+}
+
+.input-field input {
+  border: none;
+  border-bottom: 1px solid #9e9e9e;
+  width: 100%;
+  padding: 4px 0 8px 0;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-bottom-color 0.3s;
+  background: transparent;
+}
+
+.input-field input:focus {
+  border-bottom: 2px solid #6200ee;
+}
+
+.btn {
+  background-color: #6200ee;
+  border: none;
+  color: white;
+  padding: 10px 16px;
+  text-align: center;
+  text-decoration: none;
+  display: block;
+  margin: 8px 0;
+  width: 100%;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.btn:hover {
+  background-color: #3700b3;
+}
+
+.btn.grey {
+  background-color: #9e9e9e;
+}
+
+.btn.grey:hover {
+  background-color: #7e7e7e;
+}


### PR DESCRIPTION
## Summary
- give extension popup a basic material design look using `style.css`
- restyle the summary widget with material-inspired fonts and buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841fcf52cf883289ffcce30106d4d88