### PR TITLE
Add framework detection button

### DIFF
--- a/content.js
+++ b/content.js
@@ -13,7 +13,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   } else if (message.action === 'remove_ads') {
     // User clicked "Remove Ads" – hide advertising elements.
     removeAds();
+  } else if (message.action === 'detect_framework') {
+    // Identify the framework/CMS used by the current page and
+    // send the result back to the popup.
+    const result = detectFramework();
+    sendResponse(result);
   }
+  return true;
 });
 
 // Creates and displays the summary widget on the current page.
@@ -173,4 +179,36 @@ function removeAds() {
     'iframe[src*="adservice" i]'
   ];
   document.querySelectorAll(selectors.join(',')).forEach(el => el.remove());
+}
+
+// Attempt to guess which framework or CMS the page is built with by
+// inspecting meta tags and common file paths. Returns a string describing
+// the detected framework or "Unknown" if no hints are found.
+function detectFramework() {
+  const generator = document.querySelector("meta[name='generator']")?.content || '';
+
+  if (/Drupal/i.test(generator)) {
+    const version = generator.match(/\d+(\.\d+)+/);
+    return version ? `Drupal ${version[0]}` : 'Drupal';
+  }
+
+  if (/WordPress/i.test(generator)) {
+    const version = generator.match(/\d+(\.\d+)+/);
+    return version ? `WordPress ${version[0]}` : 'WordPress';
+  }
+
+  if (/Joomla/i.test(generator)) {
+    const version = generator.match(/\d+(\.\d+)+/);
+    return version ? `Joomla ${version[0]}` : 'Joomla';
+  }
+
+  if (document.querySelector("link[href*='wp-content'], script[src*='wp-content']")) {
+    return 'WordPress';
+  }
+
+  if (document.querySelector("script[src*='drupal'], link[href*='drupal'], [data-drupal-selector]")) {
+    return 'Drupal';
+  }
+
+  return 'Unknown';
 }

--- a/popup.html
+++ b/popup.html
@@ -19,6 +19,7 @@
   <button id="saveKeyBtn" class="btn">Save Key</button>
   <button id="summarizeBtn" class="btn">Summarize</button>
   <button id="removeAdsBtn" class="btn grey">Remove Ads</button>
+  <button id="detectFrameworkBtn" class="btn">Detect Framework</button>
 
   <!-- The popup script handles button actions -->
   <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -25,3 +25,12 @@ document.getElementById('removeAdsBtn').addEventListener('click', async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   chrome.tabs.sendMessage(tab.id, { action: 'remove_ads' });
 });
+
+// The "Detect Framework" button attempts to identify what CMS or
+// framework the current site is built with and alerts the result.
+document.getElementById('detectFrameworkBtn').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  chrome.tabs.sendMessage(tab.id, { action: 'detect_framework' }, (response) => {
+    alert(`Framework: ${response || 'Unknown'}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add a **Detect Framework** button to popup
- send message to content script to detect the CMS or framework
- analyze meta tags and file paths to guess if the site uses Drupal, WordPress, Joomla and return the version if found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684201ab240483289278ac1a80549769