### PR TITLE
Add domain info lookup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -19,6 +19,7 @@
   <button id="saveKeyBtn" class="btn">Save Key</button>
   <button id="summarizeBtn" class="btn">Summarize</button>
   <button id="removeAdsBtn" class="btn grey">Remove Ads</button>
+  <button id="lookupBtn" class="btn grey">Domain Info</button>
 
   <!-- The popup script handles button actions -->
   <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -25,3 +25,38 @@ document.getElementById('removeAdsBtn').addEventListener('click', async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   chrome.tabs.sendMessage(tab.id, { action: 'remove_ads' });
 });
+
+// The "Domain Info" button attempts to look up DNS and WHOIS data for the
+// current tab's domain and displays a simple alert with the results.
+document.getElementById('lookupBtn').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = new URL(tab.url);
+  const domain = url.hostname;
+
+  try {
+    const dnsRes = await fetch(`https://dns.google/resolve?name=${domain}&type=A`);
+    const dnsData = await dnsRes.json();
+    const ip = dnsData.Answer?.[0]?.data || 'Unknown';
+
+    const whoisRes = await fetch(`https://rdap.org/domain/${domain}`);
+    const whoisData = await whoisRes.json();
+    const registrant = (whoisData.entities || []).find(e => (e.roles || []).includes('registrant'));
+    const owner = registrant?.vcardArray?.[1]?.find(v => v[0] === 'fn')?.[3] || 'Unknown';
+
+    let hostInfo = '';
+    if (ip !== 'Unknown') {
+      try {
+        const ipRes = await fetch(`https://ipinfo.io/${ip}/json`);
+        const ipData = await ipRes.json();
+        hostInfo = ipData.org ? `${ipData.org} (${ipData.country})` : ipData.country || '';
+      } catch (err) {
+        hostInfo = '';
+      }
+    }
+
+    const message = `Domain: ${domain}\nOwner: ${owner}\nIP: ${ip}${hostInfo ? `\nHost: ${hostInfo}` : ''}`;
+    alert(message);
+  } catch (err) {
+    alert('Failed to lookup domain information.');
+  }
+});


### PR DESCRIPTION
## Summary
- add a Domain Info button in the popup
- implement lookup for DNS, WHOIS and hosting info via popup.js

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684201db9b84832893da7953f064e892