### PR TITLE
Fix message listener return value

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,7 +19,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const result = detectFramework();
     sendResponse(result);
   }
-  return true;
+  // No asynchronous response, so we don't keep the message port open.
+  return false;
 });
 
 // Creates and displays the summary widget on the current page.


### PR DESCRIPTION
## Summary
- avoid keeping the message port open after handling popup messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684207096e948328a93a85481132be4c