### PR TITLE
Add API key field status indicator

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -6,10 +6,28 @@
 
 // When the "Save Key" button is clicked we store the API key using
 // chrome.storage so it can be accessed by the content script later.
+const apiKeyInput = document.getElementById('apiKeyInput');
+
+function updateKeyColor(key) {
+  if (key) {
+    apiKeyInput.classList.remove('key-missing');
+    apiKeyInput.classList.add('key-stored');
+  } else {
+    apiKeyInput.classList.remove('key-stored');
+    apiKeyInput.classList.add('key-missing');
+  }
+}
+
+chrome.storage.local.get('openai_api_key', ({ openai_api_key }) => {
+  apiKeyInput.value = openai_api_key || '';
+  updateKeyColor(openai_api_key);
+});
+
 document.getElementById('saveKeyBtn').addEventListener('click', () => {
-  const key = document.getElementById('apiKeyInput').value.trim();
+  const key = apiKeyInput.value.trim();
   chrome.storage.local.set({ openai_api_key: key }, () => {
     alert('API Key saved!');
+    updateKeyColor(key);
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -30,6 +30,15 @@ body {
   background: transparent;
 }
 
+/* Background indicates whether an API key is stored */
+.input-field input.key-stored {
+  background-color: #d4edda; /* light green */
+}
+
+.input-field input.key-missing {
+  background-color: #f8d7da; /* light red */
+}
+
 /* Highlight the bottom border when the input is focused */
 .input-field input:focus {
   border-bottom: 2px solid #6200ee;


### PR DESCRIPTION
## Summary
- highlight OpenAI key input red if no key is saved and green when a key exists

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842117c30a083288b504316abf7fc88