### PR TITLE
Improve history page style

### DIFF
--- a/history.html
+++ b/history.html
@@ -7,8 +7,10 @@
   <title>Summary History</title>
 </head>
 <body>
-  <h5 class="title">Summary History</h5>
-  <ul id="historyList" style="list-style:none; padding:0;"></ul>
+  <div class="history-container">
+    <h5 class="title">Summary History</h5>
+    <ul id="historyList" class="history-list"></ul>
+  </div>
   <script src="history.js"></script>
 </body>
 </html>

--- a/history.js
+++ b/history.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     list.innerHTML = '';
     history.forEach((item, idx) => {
       const li = document.createElement('li');
-      li.style.marginBottom = '16px';
+      li.className = 'history-item';
       li.innerHTML = `
         <div><a href="${item.url}" target="_blank">${item.url}</a> - ${new Date(item.timestamp).toLocaleString()}</div>
         <div>${item.summary}</div>

--- a/style.css
+++ b/style.css
@@ -84,3 +84,36 @@ body {
 .btn.tertiary:hover {
   background-color: #bdbdbd;
 }
+/* History page container */
+/* History list styling */
+.history-list {
+  list-style: none;
+  padding: 0;
+}
+.history-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* Individual history item styled like a Material card */
+.history-item {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background-color: #fff;
+}
+
+.history-item a {
+  color: #6200ee;
+  text-decoration: none;
+}
+.history-item a:hover {
+  text-decoration: underline;
+}
+
+/* Delete button in history items */
+.history-item .btn {
+  width: auto;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- style history page container and items like material cards
- wrap history list and remove inline styles
- apply history-item class in JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684216fae0c0832896c83c491c4b62e7