### PR TITLE
Improve saved pages display

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Every time a summary is generated the extension saves it locally with the page U
 
 ## Save Pages
 
-Press the **Save Page** button in the popup to store the full HTML of the current site for offline reading. Ads are removed automatically but all other content, including images, is preserved. Saved pages are listed in the history view where you can open or delete them.
+Press the **Save Page** button in the popup to store the full HTML of the current site for offline reading. Ads are removed automatically but all other content, including images, is preserved. Saved pages are listed in the history view where the full page is embedded for quick reference. You can delete any entry at any time.
 
 ## Manage Cookies
 

--- a/history.js
+++ b/history.js
@@ -24,9 +24,13 @@ document.addEventListener('DOMContentLoaded', () => {
     pages.forEach((item, idx) => {
       const li = document.createElement('li');
       li.className = 'history-item';
+
+      const blob = new Blob([item.content], { type: 'text/html' });
+      const viewUrl = URL.createObjectURL(blob);
+
       li.innerHTML = `
         <div><a href="${item.url}" target="_blank">${item.url}</a> - ${new Date(item.timestamp).toLocaleString()}</div>
-        <button data-index="${idx}" class="btn secondary view">View</button>
+        <iframe src="${viewUrl}" class="saved-page-frame"></iframe>
         <button data-index="${idx}" class="btn tertiary delete">Delete</button>
       `;
       pageList.appendChild(li);
@@ -49,17 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   pageList.addEventListener('click', (e) => {
-    if (e.target.classList.contains('view')) {
-      const idx = parseInt(e.target.dataset.index, 10);
-      chrome.storage.local.get({ page_history: [] }, ({ page_history }) => {
-        const page = page_history[idx];
-        if (page) {
-          const blob = new Blob([page.content], { type: 'text/html' });
-          const url = URL.createObjectURL(blob);
-          chrome.tabs.create({ url });
-        }
-      });
-    } else if (e.target.classList.contains('delete')) {
+    if (e.target.classList.contains('delete')) {
       const idx = parseInt(e.target.dataset.index, 10);
       chrome.storage.local.get({ page_history: [] }, ({ page_history }) => {
         page_history.splice(idx, 1);

--- a/style.css
+++ b/style.css
@@ -139,6 +139,14 @@ body {
   width: auto;
   margin-top: 8px;
 }
+
+.saved-page-frame {
+  width: 100%;
+  height: 400px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  margin-top: 8px;
+}
 /* Modal overlay for cookie management */
 .modal-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- embed saved pages directly in history.html
- remove view button logic
- add styling for embedded pages
- clarify README about saved pages

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684b3846de808328a5caf8f51aae1616