### PR TITLE
Add enable JS tertiary button

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Press the **Analyze Bias** button to check if a news article leans left, right o
 ## Bypass JavaScript
 
 Click the **Bypass** button to reload the current page with JavaScript disabled. This can help access content that normally requires scripts to run.
+
+## Enable JavaScript
+
+Use the **Enable JS** button to restore scripting. The page is reloaded with JavaScript allowed again.

--- a/popup.html
+++ b/popup.html
@@ -39,6 +39,7 @@
     <button id="detectFrameworkBtn" class="btn tertiary">Detect Framework</button>
     <button id="lookupBtn" class="btn tertiary">Domain Info</button>
     <button id="historyBtn" class="btn tertiary">History</button>
+    <button id="enableJsBtn" class="btn tertiary">Enable JS</button>
   </div>
 
   <!-- The popup script handles button actions -->

--- a/popup.js
+++ b/popup.js
@@ -80,6 +80,20 @@ document.getElementById('bypassBtn').addEventListener('click', async () => {
   }
 });
 
+// Reload the page with JavaScript enabled
+document.getElementById('enableJsBtn').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  try {
+    const url = new URL(tab.url);
+    const pattern = `${url.origin}/*`;
+    chrome.contentSettings.javascript.set({ primaryPattern: pattern, setting: 'allow' }, () => {
+      chrome.tabs.reload(tab.id);
+    });
+  } catch (err) {
+    alert('Unable to enable JavaScript for this page.');
+  }
+});
+
 // Simple descriptions for common tracking cookies
 function getCookieDescription(name) {
   const lower = name.toLowerCase();


### PR DESCRIPTION
## Summary
- add an `Enable JS` button to restore JavaScript
- reload the page with scripting allowed when clicked
- mention feature in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852ee7aaf98832886a9ddb0435b3bba