### PR TITLE
Use Apple system fonts with iOS-style spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,15 +7,17 @@
 
 /* Overall styling for the popup window */
 body {
-  font-family: Roboto, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', sans-serif;
+  line-height: 1.4;
   padding: 16px;
   margin: 0;
 }
 
 /* Header text at the top of the popup */
 .title {
-  margin-bottom: 20px;
+  margin-bottom: 24px;
   font-size: 1.25rem;
+  font-weight: 600;
 }
 
 /* Styles for the API key input box */
@@ -195,6 +197,7 @@ body {
   margin-top: 0;
   margin-bottom: 16px;
   font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .modal ul {


### PR DESCRIPTION
## Summary
- use system `-apple-system` font stack for popup styling
- add iOS-friendly line-height and spacing, including stronger heading weight

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes playwright@latest install chromium webkit` *(host dependency warnings, browsers downloaded)*
- `node - <<'NODE' ...` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68af6316324c83289adf653b6e2924a8