### PR TITLE
Revamp popup actions layout

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -22,27 +22,70 @@
     </select>
   </div>
 
-  <!-- Buttons ordered by importance -->
-  <div class="button-row primary-buttons">
-    <button id="summarizeBtn" class="btn primary">Summarize</button>
-  </div>
-  <div class="button-row secondary-buttons">
-    <button id="summarizeSelectionBtn" class="btn secondary">Summarize Selection</button>
-    <button id="biasBtn" class="btn secondary">Analyze Bias</button>
-    <button id="removeAdsBtn" class="btn secondary">Remove Ads</button>
-    <button id="checkCookiesBtn" class="btn secondary">Manage Cookies</button>
-    <button id="savePageBtn" class="btn secondary">Save Page</button>
-    <button id="bypassBtn" class="btn secondary">Bypass</button>
-  </div>
-  <div class="button-row tertiary-buttons">
-    <button id="saveKeyBtn" class="btn tertiary">Save Key</button>
-    <button id="detectFrameworkBtn" class="btn tertiary">Detect Framework</button>
-    <button id="lookupBtn" class="btn tertiary">Domain Info</button>
-    <button id="historyBtn" class="btn tertiary">History</button>
-    <button id="enableJsBtn" class="btn tertiary">Enable JS</button>
+  <!-- Primary action -->
+  <div class="actions">
+    <button id="summarizeBtn" class="btn primary action-item">
+      <svg viewBox="0 0 24 24"><path d="M4 4h16v2H4zm0 4h16v2H4zm0 4h10v2H4z"/></svg>
+      <span>Summarize</span>
+    </button>
+
+    <!-- Toggle for more actions -->
+    <button id="toggleMoreBtn" class="btn tertiary action-item">
+      <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+      <span>More Actions</span>
+    </button>
+
+    <!-- Collapsible more actions section -->
+    <div id="moreActions" class="actions" hidden>
+      <button id="summarizeSelectionBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Summarize Selection</span>
+      </button>
+      <button id="biasBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Analyze Bias</span>
+      </button>
+      <button id="removeAdsBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Remove Ads</span>
+      </button>
+      <button id="checkCookiesBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Manage Cookies</span>
+      </button>
+      <button id="savePageBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Save Page</span>
+      </button>
+      <button id="bypassBtn" class="btn secondary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Bypass</span>
+      </button>
+      <button id="saveKeyBtn" class="btn tertiary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Save Key</span>
+      </button>
+      <button id="detectFrameworkBtn" class="btn tertiary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Detect Framework</span>
+      </button>
+      <button id="lookupBtn" class="btn tertiary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Domain Info</span>
+      </button>
+      <button id="historyBtn" class="btn tertiary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>History</span>
+      </button>
+      <button id="enableJsBtn" class="btn tertiary action-item">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <span>Enable JS</span>
+      </button>
+    </div>
   </div>
 
   <!-- The popup script handles button actions -->
   <script src="popup.js"></script>
 </body>
 </html>
+

--- a/popup.js
+++ b/popup.js
@@ -225,3 +225,12 @@ document.getElementById('historyBtn').addEventListener('click', () => {
     chrome.tabs.create({ url: chrome.runtime.getURL('history.html') });
   }
 });
+
+// Toggle visibility of the additional actions
+const toggleMoreBtn = document.getElementById('toggleMoreBtn');
+const moreActions = document.getElementById('moreActions');
+
+toggleMoreBtn.addEventListener('click', () => {
+  moreActions.hidden = !moreActions.hidden;
+  toggleMoreBtn.classList.toggle('expanded', !moreActions.hidden);
+});

--- a/style.css
+++ b/style.css
@@ -91,6 +91,35 @@ body {
   margin: 4px;
 }
 
+/* Container for action buttons */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Individual action buttons contain an icon and label */
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  height: 44px;
+}
+
+.action-item svg {
+  width: 20px;
+  height: 20px;
+}
+
+#toggleMoreBtn svg {
+  transition: transform 0.2s;
+}
+
+#toggleMoreBtn.expanded svg {
+  transform: rotate(180deg);
+}
+
 /* Primary action button */
 .btn.primary {
   background-color: #6200ee;


### PR DESCRIPTION
## Summary
- Restructure popup buttons into vertical stack with primary action and expandable more-actions list
- Add SVG icons and flex styling for buttons
- Provide chevron toggle with JavaScript for secondary/tertiary tools

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af631725a88328904ed14b9a4140da