### PR TITLE
feat: apply glassmorphism to buttons and modals

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ body {
 
 /* Generic button style used for all buttons in the popup */
 .btn {
-  border: none;
+  border: 1px solid rgba(255, 255, 255, 0.3);
   color: white;
   padding: 6px 12px;
   text-align: center;
@@ -69,10 +69,11 @@ body {
   display: inline-block;
   margin: 0;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: 12px;
   transition: background-color 0.2s;
   font-size: 0.875rem;
-  width:100%
+  width:100%;
+  backdrop-filter: blur(20px);
 }
 
 /* Layout helpers for popup buttons */
@@ -93,29 +94,32 @@ body {
 
 /* Primary action button */
 .btn.primary {
-  background-color: #6200ee;
+  background-color: rgba(98, 0, 238, 0.2);
   padding:10px;
 }
-.btn.primary:hover {
-  background-color: #3700b3;
+.btn.primary:hover,
+.btn.primary:focus {
+  background-color: rgba(98, 0, 238, 0.3);
 }
 
 /* Secondary actions */
 .btn.secondary {
-  background-color: #9e9e9e;
+  background-color: rgba(158, 158, 158, 0.2);
   color: #fff;
 }
-.btn.secondary:hover {
-  background-color: #7e7e7e;
+.btn.secondary:hover,
+.btn.secondary:focus {
+  background-color: rgba(158, 158, 158, 0.3);
 }
 
 /* Tertiary actions */
 .btn.tertiary {
-  background-color: #e0e0e0;
+  background-color: rgba(224, 224, 224, 0.2);
   color: #000;
 }
-.btn.tertiary:hover {
-  background-color: #bdbdbd;
+.btn.tertiary:hover,
+.btn.tertiary:focus {
+  background-color: rgba(224, 224, 224, 0.3);
 }
 /* History page container */
 /* History list styling */
@@ -172,7 +176,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(255, 255, 255, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,9 +185,11 @@ body {
 }
 
 .modal {
-  background: #fff;
+  background: rgba(255, 255, 255, 0.2);
   padding: 24px;
-  border-radius: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(20px);
   max-width: 360px;
   width: 100%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2),


### PR DESCRIPTION
## Summary
- Restyle buttons with translucent backgrounds, glass edge borders, and blur for a glassmorphism look
- Lighten modal overlay and blur modal container for depth
- Use opacity-based hover and focus states instead of darkening colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6317add4832898183f507deb9f4a