### PR TITLE
Add theme variables for dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,11 +5,47 @@
  * development.  Each section below targets a specific element in the popup.
  */
 
+:root {
+  --accent-color: #6200ee;
+  --accent-color-hover: #3700b3;
+  --secondary-color: #9e9e9e;
+  --secondary-color-hover: #7e7e7e;
+  --tertiary-color: #e0e0e0;
+  --tertiary-color-hover: #bdbdbd;
+  --glass-surface: #ffffff;
+  --text-color: #000000;
+  --button-text-color: #ffffff;
+  --border-color: #cccccc;
+  --overlay-bg: rgba(0, 0, 0, 0.5);
+  --success-bg: #d4edda;
+  --error-bg: #f8d7da;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --accent-color: #bb86fc;
+    --accent-color-hover: #985eff;
+    --secondary-color: #b0b0b0;
+    --secondary-color-hover: #c5c5c5;
+    --tertiary-color: #333333;
+    --tertiary-color-hover: #444444;
+    --glass-surface: #121212;
+    --text-color: #ffffff;
+    --button-text-color: #000000;
+    --border-color: #444444;
+    --overlay-bg: rgba(0, 0, 0, 0.8);
+    --success-bg: #274a2a;
+    --error-bg: #5a1b1b;
+  }
+}
+
 /* Overall styling for the popup window */
 body {
   font-family: Roboto, Arial, sans-serif;
   padding: 16px;
   margin: 0;
+  background-color: var(--glass-surface);
+  color: var(--text-color);
 }
 
 /* Header text at the top of the popup */
@@ -21,7 +57,7 @@ body {
 /* Styles for the API key input box */
 .input-field input {
   border: none;
-  border-bottom: 1px solid #9e9e9e;
+  border-bottom: 1px solid var(--secondary-color);
   width: 100%;
   padding: 4px 0 8px 0;
   box-sizing: border-box;
@@ -33,7 +69,7 @@ body {
 /* Dropdown styling matches the input field */
 .input-field select {
   border: none;
-  border-bottom: 1px solid #9e9e9e;
+  border-bottom: 1px solid var(--secondary-color);
   width: 100%;
   padding: 4px 0 8px 0;
   box-sizing: border-box;
@@ -43,26 +79,26 @@ body {
 
 /* Background indicates whether an API key is stored */
 .input-field input.key-stored {
-  background-color: #d4edda; /* light green */
+  background-color: var(--success-bg);
 }
 
 .input-field input.key-missing {
-  background-color: #f8d7da; /* light red */
+  background-color: var(--error-bg);
 }
 
 /* Highlight the bottom border when the input is focused */
 .input-field input:focus {
-  border-bottom: 2px solid #6200ee;
+  border-bottom: 2px solid var(--accent-color);
 }
 
 .input-field select:focus {
-  border-bottom: 2px solid #6200ee;
+  border-bottom: 2px solid var(--accent-color);
 }
 
 /* Generic button style used for all buttons in the popup */
 .btn {
   border: none;
-  color: white;
+  color: var(--button-text-color);
   padding: 6px 12px;
   text-align: center;
   text-decoration: none;
@@ -93,29 +129,28 @@ body {
 
 /* Primary action button */
 .btn.primary {
-  background-color: #6200ee;
+  background-color: var(--accent-color);
   padding:10px;
 }
 .btn.primary:hover {
-  background-color: #3700b3;
+  background-color: var(--accent-color-hover);
 }
 
 /* Secondary actions */
 .btn.secondary {
-  background-color: #9e9e9e;
-  color: #fff;
+  background-color: var(--secondary-color);
 }
 .btn.secondary:hover {
-  background-color: #7e7e7e;
+  background-color: var(--secondary-color-hover);
 }
 
 /* Tertiary actions */
 .btn.tertiary {
-  background-color: #e0e0e0;
-  color: #000;
+  background-color: var(--tertiary-color);
+  color: var(--text-color);
 }
 .btn.tertiary:hover {
-  background-color: #bdbdbd;
+  background-color: var(--tertiary-color-hover);
 }
 /* History page container */
 /* History list styling */
@@ -136,7 +171,7 @@ body {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 16px;
   padding: 16px;
-  background-color: #fff;
+  background-color: var(--glass-surface);
   flex: 1 1 calc(50% - 16px);
   min-width: 250px;
   box-sizing: border-box;
@@ -145,7 +180,7 @@ body {
 }
 
 .history-item a {
-  color: #6200ee;
+  color: var(--accent-color);
   text-decoration: none;
 }
 .history-item a:hover {
@@ -161,7 +196,7 @@ body {
 .saved-page-frame {
   width: 100%;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   margin-top: 8px;
 }
@@ -172,7 +207,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,7 +216,7 @@ body {
 }
 
 .modal {
-  background: #fff;
+  background: var(--glass-surface);
   padding: 24px;
   border-radius: 8px;
   max-width: 360px;
@@ -189,6 +224,7 @@ body {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2),
               0 8px 16px rgba(0, 0, 0, 0.2);
   animation: modal-fade-in 0.2s ease-out;
+  color: var(--text-color);
 }
 
 .modal h4 {


### PR DESCRIPTION
## Summary
- define CSS variables for accent, surface, and support colors
- apply variables across inputs, buttons, modals so theme tracks OS color scheme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af631b39188328bb5eab3f9e583c4f