### PR TITLE
Inline container style snippet

### DIFF
--- a/container.style
+++ b/container.style
@@ -1,8 +1,0 @@
-// Additional styling that is appended to the summary widget's container.
-// Keeping this snippet in its own file makes it easy to tweak text styling
-// without digging through the content script.
-container.style += `
-  font-size: 14px;
-  line-height: 1.5;
-  color: #222;
-`;

--- a/content.js
+++ b/content.js
@@ -57,6 +57,9 @@ function createFloatingWidget(titleText, maxHeight = '70vh') {
     resize: both;
     left: auto;
     top: auto;
+    font-size: 14px;
+    line-height: 1.5;
+    color: #222;
   `;
 
   const title = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove redundant `container.style` file
- apply its font and color rules directly in the summary widget's container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b212bf883288821921e93bda6fe