### PR TITLE
Handle non-OK responses

### DIFF
--- a/content.js
+++ b/content.js
@@ -250,8 +250,12 @@ async function fetchSummary(text, apiKey, tone = 'Executive') {
 
     // The API returns an object with an array of choices. We take the first
     // choice's message content as our summary.
-    const data = await response.json();
-    summary = data.choices?.[0]?.message?.content || '❌ No summary returned.';
+    if (!response.ok) {
+      summary = `❌ Error fetching summary. (${response.status})`;
+    } else {
+      const data = await response.json();
+      summary = data.choices?.[0]?.message?.content || '❌ No summary returned.';
+    }
   } catch (err) {
     // Handle errors such as network failures or invalid API keys
     summary = '❌ Error fetching summary.';
@@ -296,6 +300,9 @@ async function fetchBias(text, apiKey, author = '') {
       }),
     });
 
+    if (!response.ok) {
+      return `❌ Error analyzing bias. (${response.status})`;
+    }
     const data = await response.json();
     return data.choices?.[0]?.message?.content || '❌ No analysis returned.';
   } catch (err) {

--- a/popup.js
+++ b/popup.js
@@ -202,10 +202,18 @@ document.getElementById('lookupBtn').addEventListener('click', async () => {
 
   try {
     const dnsRes = await fetch(`https://dns.google/resolve?name=${domain}&type=A`);
+    if (!dnsRes.ok) {
+      alert('DNS lookup failed.');
+      return;
+    }
     const dnsData = await dnsRes.json();
     const ip = dnsData.Answer?.[0]?.data || 'Unknown';
 
     const whoisRes = await fetch(`https://rdap.org/domain/${domain}`);
+    if (!whoisRes.ok) {
+      alert('WHOIS lookup failed.');
+      return;
+    }
     const whoisData = await whoisRes.json();
     const registrant = (whoisData.entities || []).find(e => (e.roles || []).includes('registrant'));
     const owner = registrant?.vcardArray?.[1]?.find(v => v[0] === 'fn')?.[3] || 'Unknown';
@@ -214,10 +222,14 @@ document.getElementById('lookupBtn').addEventListener('click', async () => {
     if (ip !== 'Unknown') {
       try {
         const ipRes = await fetch(`https://ipinfo.io/${ip}/json`);
-        const ipData = await ipRes.json();
-        hostInfo = ipData.org ? `${ipData.org} (${ipData.country})` : ipData.country || '';
+        if (!ipRes.ok) {
+          alert('IP info lookup failed.');
+        } else {
+          const ipData = await ipRes.json();
+          hostInfo = ipData.org ? `${ipData.org} (${ipData.country})` : ipData.country || '';
+        }
       } catch (err) {
-        hostInfo = '';
+        alert('IP info lookup failed.');
       }
     }
 


### PR DESCRIPTION
## Summary
- Guard `fetchSummary` and `fetchBias` against failed responses and return clear error messages.
- Validate DNS, WHOIS, and IP fetch responses in the popup domain lookup and alert on failures.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6c06ed008328b85595baed1d4c72