### PR TITLE
Apply glassmorphism blur and contrast tweaks

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@
   --secondary-color-hover: #7e7e7e;
   --tertiary-color: #e0e0e0;
   --tertiary-color-hover: #bdbdbd;
-  --glass-surface: #ffffff;
+  --glass-surface: rgba(255, 255, 255, 0.2);
   --text-color: #000000;
   --button-text-color: #ffffff;
   --border-color: #cccccc;
@@ -29,7 +29,7 @@
     --secondary-color-hover: #c5c5c5;
     --tertiary-color: #333333;
     --tertiary-color-hover: #444444;
-    --glass-surface: #121212;
+    --glass-surface: rgba(18, 18, 18, 0.2);
     --text-color: #ffffff;
     --button-text-color: #000000;
     --border-color: #444444;
@@ -47,6 +47,9 @@ body {
   margin: 0;
   background-color: var(--glass-surface);
   color: var(--text-color);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
 /* Header text at the top of the popup */


### PR DESCRIPTION
## Summary
- Replace solid `--glass-surface` colors with semi-transparent rgba values for light and dark themes
- Blur popup backgrounds via `backdrop-filter`/`-webkit-backdrop-filter`
- Add subtle text shadow to preserve readability on translucent surfaces

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e61a56883289384f11f5485ded0