### PR TITLE
Use SF Symbols icons for popup actions

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -25,60 +25,60 @@
   <!-- Primary action -->
   <div class="actions">
     <button id="summarizeBtn" class="btn primary action-item">
-      <svg viewBox="0 0 24 24"><path d="M4 4h16v2H4zm0 4h16v2H4zm0 4h10v2H4z"/></svg>
+      <svg class="icon"><use href="sf-symbols.svg#doc.text.magnifyingglass"/></svg>
       <span>Summarize</span>
     </button>
 
     <!-- Toggle for more actions -->
     <button id="toggleMoreBtn" class="btn tertiary action-item">
-      <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+      <svg class="icon"><use href="sf-symbols.svg#chevron.down"/></svg>
       <span>More Actions</span>
     </button>
 
     <!-- Collapsible more actions section -->
     <div id="moreActions" class="actions" hidden>
       <button id="summarizeSelectionBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#text.badge.plus"/></svg>
         <span>Summarize Selection</span>
       </button>
       <button id="biasBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#chart.bar"/></svg>
         <span>Analyze Bias</span>
       </button>
       <button id="removeAdsBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#eye.slash"/></svg>
         <span>Remove Ads</span>
       </button>
       <button id="checkCookiesBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#checkmark.shield"/></svg>
         <span>Manage Cookies</span>
       </button>
       <button id="savePageBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#square.and.arrow.down"/></svg>
         <span>Save Page</span>
       </button>
       <button id="bypassBtn" class="btn secondary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#arrowshape.turn.up.right"/></svg>
         <span>Bypass</span>
       </button>
       <button id="saveKeyBtn" class="btn tertiary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#key"/></svg>
         <span>Save Key</span>
       </button>
       <button id="detectFrameworkBtn" class="btn tertiary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#cpu"/></svg>
         <span>Detect Framework</span>
       </button>
       <button id="lookupBtn" class="btn tertiary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#globe"/></svg>
         <span>Domain Info</span>
       </button>
       <button id="historyBtn" class="btn tertiary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#clock.arrow.circlepath"/></svg>
         <span>History</span>
       </button>
       <button id="enableJsBtn" class="btn tertiary action-item">
-        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/></svg>
+        <svg class="icon"><use href="sf-symbols.svg#curlybraces"/></svg>
         <span>Enable JS</span>
       </button>
     </div>

--- a/sf-symbols.svg
+++ b/sf-symbols.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="doc.text.magnifyingglass" viewBox="0 0 24 24">
+    <rect x="3" y="3" width="14" height="18" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="6" y1="7" x2="14" y2="7" stroke="currentColor" stroke-width="2"/>
+    <line x1="6" y1="11" x2="14" y2="11" stroke="currentColor" stroke-width="2"/>
+    <line x1="6" y1="15" x2="12" y2="15" stroke="currentColor" stroke-width="2"/>
+    <circle cx="18" cy="18" r="3" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="20" y1="20" x2="23" y2="23" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="chevron.down" viewBox="0 0 24 24">
+    <path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="text.badge.plus" viewBox="0 0 24 24">
+    <rect x="4" y="4" width="16" height="12" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="12" y1="8" x2="12" y2="16" stroke="currentColor" stroke-width="2"/>
+    <line x1="8" y1="12" x2="16" y2="12" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="chart.bar" viewBox="0 0 24 24">
+    <line x1="3" y1="19" x2="21" y2="19" stroke="currentColor" stroke-width="2"/>
+    <rect x="5" y="11" width="3" height="8" fill="currentColor"/>
+    <rect x="10" y="7" width="3" height="12" fill="currentColor"/>
+    <rect x="15" y="3" width="3" height="16" fill="currentColor"/>
+  </symbol>
+  <symbol id="eye.slash" viewBox="0 0 24 24">
+    <path d="M1 12s5-7 11-7 11 7 11 7-5 7-11 7S1 12 1 12z" fill="none" stroke="currentColor" stroke-width="2"/>
+    <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M2 2l20 20" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="checkmark.shield" viewBox="0 0 24 24">
+    <path d="M12 2l8 4v5c0 5.25-3.5 10-8 11-4.5-1-8-5.75-8-11V6l8-4z" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M8 12l2 2 4-4" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="square.and.arrow.down" viewBox="0 0 24 24">
+    <rect x="4" y="4" width="16" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M12 8v8" stroke="currentColor" stroke-width="2"/>
+    <path d="M8 12l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="arrowshape.turn.up.right" viewBox="0 0 24 24">
+    <path d="M4 16v-6a4 4 0 014-4h8" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M12 4l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="key" viewBox="0 0 24 24">
+    <circle cx="9" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M12 12h10v4h-4v-2h-2v2h-4z" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="cpu" viewBox="0 0 24 24">
+    <rect x="5" y="5" width="14" height="14" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="2"/>
+    <rect x="9" y="9" width="6" height="6" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M9 1v4M15 1v4M9 19v4M15 19v4M1 9h4M1 15h4M19 9h4M19 15h4" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="globe" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"/>
+    <ellipse cx="12" cy="12" rx="9" ry="4" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="clock.arrow.circlepath" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M12 7v5l3 3" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M3 3v5h5" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M21 12a9 9 0 11-9-9" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="curlybraces" viewBox="0 0 24 24">
+    <path d="M10 4c-2 0-2 2-2 4v2c0 2-2 2-2 2s2 0 2 2v2c0 2 0 4 2 4M14 4c2 0 2 2 2 4v2c0 2 2 2 2 2s-2 0-2 2v2c0 2 0 4-2 4" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+</svg>

--- a/style.css
+++ b/style.css
@@ -152,8 +152,9 @@ body {
 }
 
 .action-item svg {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
 }
 
 #toggleMoreBtn svg {


### PR DESCRIPTION
## Summary
- Add local `sf-symbols.svg` sprite with SF Symbol names for extension actions
- Replace inline placeholder graphics with `<svg><use>` references to SF Symbols
- Tweak `.action-item svg` to 24×24 for consistent sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af714e71c083288bcc6ba90cf01c23