### PR TITLE
Organize extra popup features into tabs

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -37,50 +37,64 @@
 
     <!-- Collapsible more actions section -->
     <div id="moreActions" class="actions" hidden>
-      <button id="summarizeSelectionBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#text.badge.plus"/></svg>
-        <span>Summarize Selection</span>
-      </button>
-      <button id="biasBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#chart.bar"/></svg>
-        <span>Analyze Bias</span>
-      </button>
-      <button id="removeAdsBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#eye.slash"/></svg>
-        <span>Remove Ads</span>
-      </button>
-      <button id="checkCookiesBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#checkmark.shield"/></svg>
-        <span>Manage Cookies</span>
-      </button>
-      <button id="savePageBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#square.and.arrow.down"/></svg>
-        <span>Save Page</span>
-      </button>
-      <button id="bypassBtn" class="btn secondary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#arrowshape.turn.up.right"/></svg>
-        <span>Bypass</span>
-      </button>
-      <button id="saveKeyBtn" class="btn tertiary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#key"/></svg>
-        <span>Save Key</span>
-      </button>
-      <button id="detectFrameworkBtn" class="btn tertiary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#cpu"/></svg>
-        <span>Detect Framework</span>
-      </button>
-      <button id="lookupBtn" class="btn tertiary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#globe"/></svg>
-        <span>Domain Info</span>
-      </button>
-      <button id="historyBtn" class="btn tertiary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#clock.arrow.circlepath"/></svg>
-        <span>History</span>
-      </button>
-      <button id="enableJsBtn" class="btn tertiary action-item">
-        <svg class="icon"><use href="sf-symbols.svg#curlybraces"/></svg>
-        <span>Enable JS</span>
-      </button>
+      <div class="segmented-control">
+        <button class="segment active" data-group="analysis">Analysis</button>
+        <button class="segment" data-group="utilities">Utilities</button>
+        <button class="segment" data-group="settings">Settings</button>
+      </div>
+
+      <div id="analysisGroup" class="actions action-group">
+        <button id="summarizeSelectionBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#text.badge.plus"/></svg>
+          <span>Summarize Selection</span>
+        </button>
+        <button id="biasBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#chart.bar"/></svg>
+          <span>Analyze Bias</span>
+        </button>
+        <button id="detectFrameworkBtn" class="btn tertiary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#cpu"/></svg>
+          <span>Detect Framework</span>
+        </button>
+        <button id="lookupBtn" class="btn tertiary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#globe"/></svg>
+          <span>Domain Info</span>
+        </button>
+      </div>
+
+      <div id="utilitiesGroup" class="actions action-group" hidden>
+        <button id="removeAdsBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#eye.slash"/></svg>
+          <span>Remove Ads</span>
+        </button>
+        <button id="checkCookiesBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#checkmark.shield"/></svg>
+          <span>Manage Cookies</span>
+        </button>
+        <button id="savePageBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#square.and.arrow.down"/></svg>
+          <span>Save Page</span>
+        </button>
+        <button id="bypassBtn" class="btn secondary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#arrowshape.turn.up.right"/></svg>
+          <span>Bypass</span>
+        </button>
+        <button id="historyBtn" class="btn tertiary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#clock.arrow.circlepath"/></svg>
+          <span>History</span>
+        </button>
+        <button id="enableJsBtn" class="btn tertiary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#curlybraces"/></svg>
+          <span>Enable JS</span>
+        </button>
+      </div>
+
+      <div id="settingsGroup" class="actions action-group" hidden>
+        <button id="saveKeyBtn" class="btn tertiary action-item">
+          <svg class="icon"><use href="sf-symbols.svg#key"/></svg>
+          <span>Save Key</span>
+        </button>
+      </div>
     </div>
   </div>
 

--- a/popup.js
+++ b/popup.js
@@ -257,3 +257,21 @@ toggleMoreBtn.addEventListener('click', () => {
   moreActions.hidden = !moreActions.hidden;
   toggleMoreBtn.classList.toggle('expanded', !moreActions.hidden);
 });
+
+// Switch between grouped extra features
+const segmentButtons = document.querySelectorAll('.segmented-control .segment');
+const groups = {
+  analysis: document.getElementById('analysisGroup'),
+  utilities: document.getElementById('utilitiesGroup'),
+  settings: document.getElementById('settingsGroup')
+};
+
+segmentButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    segmentButtons.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    Object.keys(groups).forEach(key => {
+      groups[key].hidden = key !== btn.dataset.group;
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -190,6 +190,35 @@ body {
 .btn.tertiary:hover {
   background-color: rgba(224, 224, 224, 0.4);
 }
+
+/* Segmented control to group extra features */
+.segmented-control {
+  display: flex;
+  margin-bottom: 8px;
+}
+
+.segmented-control .segment {
+  flex: 1;
+  padding: 6px 0;
+  border: 1px solid var(--border-color);
+  background: var(--tertiary-color);
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.segmented-control .segment + .segment {
+  border-left: none;
+}
+
+.segmented-control .segment.active {
+  background: var(--accent-color);
+  color: var(--button-text-color);
+}
+
+.action-group {
+  margin-top: 8px;
+}
 /* History page container */
 /* History list styling */
 .history-list {


### PR DESCRIPTION
## Summary
- Group extended popup features into Analysis, Utilities, and Settings categories
- Add segmented control in `popup.html` for switching between feature groups
- Implement segment switching logic in `popup.js` and add CSS styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af7672c9cc8328a6fbcf1861b9420f