### PR TITLE
Increase popup font size

### DIFF
--- a/content.js
+++ b/content.js
@@ -57,8 +57,8 @@ function createFloatingWidget(titleText, maxHeight = '70vh') {
     resize: both;
     left: auto;
     top: auto;
-    font-size: 14px;
-    line-height: 1.5;
+    font-size: 1rem;
+    line-height: 1.25;
     color: #222;
   `;
 
@@ -76,7 +76,7 @@ function createFloatingWidget(titleText, maxHeight = '70vh') {
   `;
 
   const content = document.createElement('div');
-  content.style = 'line-height: 1.5; font-size: 14px; margin-top: 8px; color: #222;';
+  content.style = 'line-height: 1.25; font-size: 1rem; margin-top: 8px; color: #222;';
 
   const copyBtn = document.createElement('button');
   copyBtn.innerText = 'Copy';

--- a/style.css
+++ b/style.css
@@ -112,7 +112,8 @@ body {
   cursor: pointer;
   border-radius: 12px;
   transition: background-color 0.2s;
-  font-size: 0.875rem;
+  font-size: 1rem;
+  line-height: 1.25;
   width: 100%;
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
@@ -204,7 +205,8 @@ body {
   background: var(--tertiary-color);
   color: var(--text-color);
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 1rem;
+  line-height: 1.25;
 }
 
 .segmented-control .segment + .segment {


### PR DESCRIPTION
## Summary
- increase popup button font size to 1rem and adjust line-height
- raise segmented control font size to match and add line-height
- scale content script widget fonts to 1rem for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` *(fails: Error: Failed to launch the browser process! libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af78275eb88328a782eb5852c5498b