### PR TITLE
Fix modal sizing to avoid horizontal scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,6 +115,7 @@ body {
   font-size: 1rem;
   line-height: 1.25;
   width: 100%;
+  box-sizing: border-box;
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
@@ -288,8 +289,10 @@ body {
   background: var(--glass-surface);
   padding: 24px;
   border-radius: 8px;
-  max-width: 360px;
-  width: 100%;
+  width: max-content;
+  min-width: 360px;
+  max-width: 90vw;
+  box-sizing: border-box;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2),
               0 8px 16px rgba(0, 0, 0, 0.2);
   animation: modal-fade-in 0.2s ease-out;


### PR DESCRIPTION
## Summary
- Allow modal to flex to button width while respecting viewport via min/max width and max-content
- Ensure buttons use border-box sizing so padding and borders stay within set width

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc908f5c83289eb3bbed7093f3f6