### PR TITLE
Add labels and text status for API key field

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -12,9 +12,14 @@
 
   <!-- Input field for the user to paste their OpenAI API key -->
   <div class="input-field">
-    <input id="apiKeyInput" type="password" placeholder="OpenAI API Key">
+    <label for="apiKeyInput" class="field-label">OpenAI API Key</label>
+    <div class="input-with-status">
+      <input id="apiKeyInput" type="password" placeholder="OpenAI API Key">
+      <span id="apiKeyStatus" class="status-indicator" role="status" aria-live="polite"></span>
+    </div>
   </div>
   <div class="input-field">
+    <label for="toneSelect" class="field-label">Tone</label>
     <select id="toneSelect">
       <option value="Executive">Executive</option>
       <option value="Bullet Points">Bullet Points</option>

--- a/popup.js
+++ b/popup.js
@@ -8,27 +8,30 @@
 // chrome.storage so it can be accessed by the content script later.
 const apiKeyInput = document.getElementById('apiKeyInput');
 const toneSelect = document.getElementById('toneSelect');
+const apiKeyStatus = document.getElementById('apiKeyStatus');
 
-function updateKeyColor(key) {
+function updateKeyStatus(key) {
   if (key) {
-    apiKeyInput.classList.remove('key-missing');
-    apiKeyInput.classList.add('key-stored');
+    apiKeyStatus.textContent = 'API key saved';
+    apiKeyStatus.classList.add('status-saved');
+    apiKeyStatus.classList.remove('status-missing');
   } else {
-    apiKeyInput.classList.remove('key-stored');
-    apiKeyInput.classList.add('key-missing');
+    apiKeyStatus.textContent = 'API key missing';
+    apiKeyStatus.classList.add('status-missing');
+    apiKeyStatus.classList.remove('status-saved');
   }
 }
 
 chrome.storage.local.get('openai_api_key', ({ openai_api_key }) => {
   apiKeyInput.value = openai_api_key || '';
-  updateKeyColor(openai_api_key);
+  updateKeyStatus(openai_api_key);
 });
 
 document.getElementById('saveKeyBtn').addEventListener('click', () => {
   const key = apiKeyInput.value.trim();
   chrome.storage.local.set({ openai_api_key: key }, () => {
     alert('API Key saved!');
-    updateKeyColor(key);
+    updateKeyStatus(key);
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -17,8 +17,8 @@
   --button-text-color: #ffffff;
   --border-color: #cccccc;
   --overlay-bg: rgba(0, 0, 0, 0.5);
-  --success-bg: #d4edda;
-  --error-bg: #f8d7da;
+  --success-color: #2e7d32;
+  --error-color: #c62828;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -34,8 +34,8 @@
     --button-text-color: #000000;
     --border-color: #444444;
     --overlay-bg: rgba(0, 0, 0, 0.8);
-    --success-bg: #274a2a;
-    --error-bg: #5a1b1b;
+    --success-color: #81c784;
+    --error-color: #ef9a9a;
   }
 }
 
@@ -60,6 +60,28 @@ body {
   font-weight: 600;
 }
 
+.input-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.input-with-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.input-with-status input {
+  flex: 1;
+}
+
 /* Styles for the API key input box */
 .input-field input {
   border: none;
@@ -81,15 +103,6 @@ body {
   box-sizing: border-box;
   outline: none;
   background: transparent;
-}
-
-/* Background indicates whether an API key is stored */
-.input-field input.key-stored {
-  background-color: var(--success-bg);
-}
-
-.input-field input.key-missing {
-  background-color: var(--error-bg);
 }
 
 /* Highlight the bottom border when the input is focused */
@@ -120,6 +133,35 @@ body {
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.status-indicator::before {
+  font-size: 0.85rem;
+}
+
+.status-indicator.status-saved {
+  color: var(--success-color);
+}
+
+.status-indicator.status-saved::before {
+  content: '✔';
+}
+
+.status-indicator.status-missing {
+  color: var(--error-color);
+}
+
+.status-indicator.status-missing::before {
+  content: '⚠';
 }
 
 /* Layout helpers for popup buttons */


### PR DESCRIPTION
## Summary
- add labels above the API key and tone controls in the popup
- show a textual status indicator instead of background colors for the stored API key
- refresh popup styles for the new labels and indicator while minimizing color-only cues

## Testing
- not run (extension has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c876be59748328b019fe1193a0c390