### PR TITLE
Add reusable toast notifications to popup and content scripts

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <div id="toastContainer" class="ws-toast-stack" aria-live="polite" aria-atomic="false"></div>
   <!-- Simple heading for the popup -->
   <h5 class="title">Summarize Page</h5>
 

--- a/style.css
+++ b/style.css
@@ -19,6 +19,11 @@
   --overlay-bg: rgba(0, 0, 0, 0.5);
   --success-color: #2e7d32;
   --error-color: #c62828;
+  --info-color: #2962ff;
+  --toast-bg: rgba(255, 255, 255, 0.95);
+  --toast-border: rgba(0, 0, 0, 0.1);
+  --toast-text-color: #1b1b1b;
+  --toast-shadow: rgba(0, 0, 0, 0.25);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -36,6 +41,11 @@
     --overlay-bg: rgba(0, 0, 0, 0.8);
     --success-color: #81c784;
     --error-color: #ef9a9a;
+    --info-color: #82b1ff;
+    --toast-bg: rgba(22, 22, 22, 0.95);
+    --toast-border: rgba(255, 255, 255, 0.12);
+    --toast-text-color: #f5f5f5;
+    --toast-shadow: rgba(0, 0, 0, 0.6);
   }
 }
 
@@ -133,6 +143,101 @@ body {
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Toast notifications used by the popup */
+.ws-toast-stack {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(320px, calc(100% - 32px));
+  z-index: 2000;
+  pointer-events: none;
+  --ws-toast-bg: var(--toast-bg);
+  --ws-toast-border: var(--toast-border);
+  --ws-toast-text: var(--toast-text-color);
+  --ws-toast-info: var(--info-color);
+  --ws-toast-success: var(--success-color);
+  --ws-toast-error: var(--error-color);
+  --ws-toast-shadow: var(--toast-shadow);
+}
+
+.ws-toast-stack.ws-toast-stack--page {
+  top: 20px;
+  bottom: auto;
+  right: 24px;
+  left: auto;
+  transform: none;
+  align-items: flex-end;
+  width: min(360px, calc(100% - 32px));
+}
+
+@media (max-width: 480px) {
+  .ws-toast-stack.ws-toast-stack--page {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    align-items: center;
+    width: calc(100% - 32px);
+  }
+}
+
+.ws-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: var(--ws-toast-bg);
+  color: var(--ws-toast-text);
+  border: 1px solid var(--ws-toast-border);
+  border-left: 4px solid var(--ws-toast-info);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px var(--ws-toast-shadow);
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  white-space: pre-line;
+}
+
+.ws-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.ws-toast__icon {
+  font-size: 1.2rem;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.ws-toast__message {
+  flex: 1;
+  white-space: inherit;
+}
+
+.ws-toast--success {
+  border-left-color: var(--ws-toast-success);
+}
+
+.ws-toast--error {
+  border-left-color: var(--ws-toast-error);
+}
+
+.ws-toast--info {
+  border-left-color: var(--ws-toast-info);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ws-toast {
+    transition: none;
+  }
 }
 
 .status-indicator {


### PR DESCRIPTION
## Summary
- add a reusable toast container in the popup and replace alerts with notification toasts
- add DOM-injected toast utilities for content scripts to surface extension messages
- style the toast component for light and dark themes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c879ef64748328bcf3498e17461d36